### PR TITLE
Removing repeated type casting and function call overhead

### DIFF
--- a/languages.go
+++ b/languages.go
@@ -524,12 +524,15 @@ var langs = [...]string{
 	"auto",
 	"auto"}
 
+//Control variable to test the validity of languages
+var langsLen Lang = Lang(len(langs))
+
 //=======================================================================
 //							Funcs
 //=======================================================================
 
 func (l Lang) valid() bool {
-	return uint8(l) < uint8(len(langs))
+	return l < langsLen
 }
 
 //Stringer interface for Lang type


### PR DESCRIPTION
The function **Valid** of the **Lang** type does 2 type castings, and checks for the size of **langs** every time it is called. Since there is no gonna be changes at runtime, I think it would be better to have some kind of control variable of the appropriate type ready to compare against to avoid the overhead.
